### PR TITLE
fix(lib): raise execFile maxBuffer so large lens output isn't truncated

### DIFF
--- a/_lens-lib/index.js
+++ b/_lens-lib/index.js
@@ -12,6 +12,10 @@ class LensRunner {
 
         return new Promise((resolve, reject) => {
             const child = execFile(cmd, args, {
+                // Node's default execFile maxBuffer is 1MB; lenses like helm3
+                // routinely exceed that on large charts (e.g. cnpg with full CRDs
+                // renders to ~1.2MB) and the child gets killed with code=null.
+                maxBuffer: 100 * 1024 * 1024,
                 ...options,
                 env: {
                     ...process.env,


### PR DESCRIPTION
## Summary

Node's `child_process.execFile` defaults to a 1MB `maxBuffer`. When a lens captures stdout exceeding that, the child is killed silently with `code=null` and output is lost. Most easily tripped by the `helm3` lens on charts with large CRDs.

## Repro

CloudNativePG chart `cloudnative-pg-v0.28.0` renders to ~1.24MB (mostly the bundled CRDs file). With the current lens code, this happens:

```
remote: executing: helm template --namespace cloudnative-pg --release-name cloudnative-pg
        --include-crds --api-versions networking.k8s.io/v1/Ingress --kube-version 1.22 .
remote: Error: Command failed with code null
```

Verified directly inside the lens container:

| Test | Output | Exit |
|---|---|---|
| `execFile('helm', ['template', ...])` (current default 1MB maxBuffer) | 1,108,985 bytes (truncated) | `null` |
| Same with `maxBuffer: 100*1024*1024` | 1,235,767 bytes (full) | `0` |

## Fix

Set `maxBuffer: 100 * 1024 * 1024` as the default in `execCommand`. Caller's `options.maxBuffer` (if any) still wins, since the spread comes after.

```js
const child = execFile(cmd, args, {
    maxBuffer: 100 * 1024 * 1024,
    ...options,
    env: { ...process.env, ...options.env }
});
```

## Test plan

- [ ] After image rebuild + republish, project a holobranch that consumes the cnpg v0.28.0 helm chart through the helm3 lens — succeeds end-to-end (currently fails with `code: null`)
- [ ] Existing smaller-output lens jobs continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)