### PR TITLE
fix(ci): only upgrade npm on release events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for trusted publishing
+        if: github.event_name == 'release'
         run: npm install -g npm@latest
 
       - name: Setting package.json version


### PR DESCRIPTION
## Summary

The `Upgrade npm for trusted publishing` step in the `publish-npm` job ran on every PR, but the actual `npm publish` step it exists to support is gated on `github.event_name == 'release'`.

On recent GH Actions runners (Node 22.22.2), `npm install -g npm@latest` itself fails:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

This is an upstream npm self-upgrade bug, but it's only relevant when we actually need a newer npm — i.e., on release. On every other event, the bundled npm 10.x is fine.

The unconditional upgrade has been breaking every PR's `Build Packages` check, which includes the `release-prepare` PR (#30 right now), which transitively blocks releases from being cut. That's how the maxBuffer fix in #29 got merged but didn't actually result in an updated `:latest` lens image — the release publish workflow never gets to run.

## Fix

One line: add `if: github.event_name == 'release'` to the npm-upgrade step, matching the existing gate on `npm publish`.

## Test plan

- [ ] This PR's own `Build Packages` check turns green (proves the unconditional upgrade was the only failure)
- [ ] After merge, PR #30 (Release: v0.8.5) re-checks green
- [ ] Release publish proceeds and pushes new `:latest` tags for the lens images

🤖 Generated with [Claude Code](https://claude.com/claude-code)